### PR TITLE
Enabled add_subdirectory() use using target_include_directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,10 +57,6 @@ endif (USE_OPENMP)
 # ==============================================================================
 SET(SOURCE_DIR "src/pymagsac")
 
-include_directories (
-	${PROJECT_SOURCE_DIR}/graph-cut-ransac/src/pygcransac/include
-)
-
 # ==============================================================================
 # Structure: Graph-Cut RANSAC Library
 # ==============================================================================
@@ -79,6 +75,8 @@ add_library(GraphCutRANSAC STATIC
 	${SRCS_GraphCutRANSAC}
 )
 
+target_include_directories(GraphCutRANSAC PUBLIC ${PROJECT_SOURCE_DIR}/graph-cut-ransac/src/pygcransac/include)
+
 target_link_libraries(GraphCutRANSAC
 	${OpenCV_LIBS}
 	Eigen3::Eigen)
@@ -86,9 +84,6 @@ target_link_libraries(GraphCutRANSAC
 # ==============================================================================
 # Structure: MAGSAC Library
 # ==============================================================================
-
-# Tell cmake that headers are in alse in source_dir
-include_directories (${SOURCE_DIR}/include)
 
 # Set header files for the library
 file(GLOB_RECURSE HDRS_MAGSAC
@@ -112,6 +107,8 @@ pybind11_add_module(pymagsac
 	${HDRS_MAGSAC} 
 	${SRCS_MAGSAC})
 
+target_include_directories(pymagsac PUBLIC ${SOURCE_DIR}/include)
+
 target_link_libraries(pymagsac PRIVATE  
 	${OpenCV_LIBS} 
 	Eigen3::Eigen
@@ -120,6 +117,9 @@ target_link_libraries(pymagsac PRIVATE
 add_library(${PROJECT_NAME} STATIC 
 	${HDRS_MAGSAC} 
 	${SRCS_MAGSAC})
+
+# Tell cmake that headers are in alse in source_dir
+target_include_directories(${PROJECT_NAME} PUBLIC ${SOURCE_DIR}/include)
 
 target_link_libraries(${PROJECT_NAME} 
 	${OpenCV_LIBS}


### PR DESCRIPTION
Hi, 
Great CMake file, it's easily readable!
I modified it to enable using it as a library from code using add_subdirectory.

I replaced include_directories with target_include_directories.

Example use:

1. Add submodule/clone repo to libs folder
2. Add following to CMake file:
```
add_subdirectory(libs/magsac)

target_link_libraries(YourProgram PUBLIC MAGSAC GraphCutRANSAC)

```