### PR TITLE
feat: add 3D plane fitting support

### DIFF
--- a/src/pymagsac/include/estimators.h
+++ b/src/pymagsac/include/estimators.h
@@ -653,6 +653,66 @@ namespace magsac
 				return 1.0 / (4.0 * getGammaFunction());
 			}
 		};
+
+		// This is the estimator class for estimating a 3D plane from a point cloud.
+		template<class _MinimalSolverEngine,  // The solver used for estimating the model from a minimal sample
+			class _NonMinimalSolverEngine> // The solver used for estimating the model from a non-minimal sample
+			class Plane3DEstimator :
+			public gcransac::estimator::LinearModelEstimator<_MinimalSolverEngine, _NonMinimalSolverEngine, 3>
+		{
+		public:
+			using gcransac::estimator::LinearModelEstimator<_MinimalSolverEngine, _NonMinimalSolverEngine, 3>::residual;
+
+			Plane3DEstimator() :
+				gcransac::estimator::LinearModelEstimator<_MinimalSolverEngine, _NonMinimalSolverEngine, 3>()
+			{}
+
+			inline double residualForScoring(const cv::Mat& point_,
+                const gcransac::Model& model_) const
+			{
+				return residual(point_, model_.descriptor);
+			}
+
+			static constexpr double getSigmaQuantile()
+			{
+				return 3.64;
+			}
+			
+			static constexpr size_t getDegreesOfFreedom()
+			{
+				return 4;
+			}
+
+			static constexpr double getC()
+			{
+				return 0.25;
+			}
+
+			static constexpr double getGammaFunction()
+			{
+				return 1.0;
+			}
+
+			static constexpr bool doesNormalizationForNonMinimalFitting()
+			{
+				return false;
+			}
+
+			static constexpr double getUpperIncompleteGammaOfK()
+			{
+				return 0.0036572608340910764;
+			}
+
+			static constexpr double getLowerIncompleteGammaOfK()
+			{
+				return 1.3012265540498875;
+			}
+
+			static constexpr double getChiSquareParamCp()
+			{
+				return 1.0 / (4.0 * getGammaFunction());
+			}
+		};
 	}
 
 	namespace utils
@@ -681,5 +741,10 @@ namespace magsac
 		typedef estimator::Line2DEstimator<gcransac::estimator::solver::LinearModelSolver<2>, // The solver used for fitting a model to a minimal sample
 			gcransac::estimator::solver::LinearModelSolver<2>>  // The solver used for fitting a model to a non-minimal sample
 			Default2DLineEstimator;
+
+		// The default estimator for 3D plane fitting
+		typedef estimator::Plane3DEstimator<gcransac::estimator::solver::LinearModelSolver<3>, // The solver used for fitting a model to a minimal sample
+			gcransac::estimator::solver::LinearModelSolver<3>>  // The solver used for fitting a model to a non-minimal sample
+			Default3DPlaneEstimator;
 	}
 }

--- a/src/pymagsac/include/magsac_python.hpp
+++ b/src/pymagsac/include/magsac_python.hpp
@@ -91,3 +91,15 @@ int findRigidTransformation_(
     int min_iters,
     int max_iters,
     int partition_num);
+
+int findPlane3D_(std::vector<double>& points,
+    std::vector<bool>& inliers,
+    std::vector<double>& plane,
+    std::vector<double>& inlier_probabilities,
+    int sampler_id,
+    bool use_magsac_plus_plus,
+    double sigma_max,
+    double conf,
+    int min_iters,
+    int max_iters,
+    int partition_num);

--- a/src/pymagsac/src/bindings.cpp
+++ b/src/pymagsac/src/bindings.cpp
@@ -392,6 +392,72 @@ py::tuple findLine2D(
     return py::make_tuple(line_, inliers_);
 }
 
+py::tuple findPlane3D(
+    py::array_t<double> points_,
+    py::array_t<double> probabilities_,
+    int sampler,
+    bool use_magsac_plus_plus,
+    double sigma_th,
+    double conf,
+    int min_iters,
+    int max_iters,
+    int partition_num)
+{
+    py::buffer_info buf1 = points_.request();
+    size_t NUM_TENTS = buf1.shape[0];
+    size_t DIM = buf1.shape[1];
+
+    if (DIM != 3)
+        throw std::invalid_argument("points should be an array with dims [n,3], n>=3");
+    if (NUM_TENTS < 3)
+        throw std::invalid_argument("points should be an array with dims [n,3], n>=3");
+
+    double* ptr1 = (double*)buf1.ptr;
+    std::vector<double> points;
+    points.assign(ptr1, ptr1 + buf1.size);
+
+    std::vector<double> plane(4);
+    std::vector<bool> inliers(NUM_TENTS);
+
+    std::vector<double> probabilities;
+    if (sampler == 3 || sampler == 4)
+    {
+        py::buffer_info buf_prob = probabilities_.request();
+        double* ptr_prob = (double*)buf_prob.ptr;
+        probabilities.assign(ptr_prob, ptr_prob + buf_prob.size);
+    }
+
+    int num_inl = findPlane3D_(
+        points,
+        inliers,
+        plane,
+        probabilities,
+        sampler,
+        use_magsac_plus_plus,
+        sigma_th,
+        conf,
+        min_iters,
+        max_iters,
+        partition_num);
+
+    py::array_t<bool> inliers_ = py::array_t<bool>(NUM_TENTS);
+    py::buffer_info buf3 = inliers_.request();
+    bool* ptr3 = (bool*)buf3.ptr;
+    for (size_t i = 0; i < NUM_TENTS; i++)
+        ptr3[i] = inliers[i];
+
+    if (num_inl == 0) {
+        return py::make_tuple(pybind11::cast<pybind11::none>(Py_None), inliers_);
+    }
+    py::array_t<double> plane_ = py::array_t<double>({4});
+    py::buffer_info buf2 = plane_.request();
+    double* ptr2 = (double*)buf2.ptr;
+    for (size_t i = 0; i < 4; i++)
+        ptr2[i] = plane[i];
+
+    return py::make_tuple(plane_, inliers_);
+}
+
 py::tuple findHomography(
     py::array_t<double>  correspondences_,
     double w1, 
@@ -553,6 +619,17 @@ PYBIND11_PLUGIN(pymagsac) {
         py::arg("points"),
         py::arg("w1"),
         py::arg("h1"),
+        py::arg("probabilities"),
+		py::arg("sampler") = 0,
+        py::arg("use_magsac_plus_plus") = true,
+        py::arg("sigma_th") = 1.0,
+        py::arg("conf") = 0.99,
+        py::arg("min_iters") = 50,
+        py::arg("max_iters") = 1000,
+        py::arg("partition_num") = 5); 
+
+  m.def("findPlane3D", &findPlane3D, R"doc(some doc)doc",
+        py::arg("points"),
         py::arg("probabilities"),
 		py::arg("sampler") = 0,
         py::arg("use_magsac_plus_plus") = true,

--- a/src/pymagsac/src/magsac_python.cpp
+++ b/src/pymagsac/src/magsac_python.cpp
@@ -590,6 +590,105 @@ int findLine2D_(std::vector<double>& pointsArr,
     return num_inliers;
 }
 
+int findPlane3D_(std::vector<double>& pointsArr,
+    std::vector<bool>& inliers,
+    std::vector<double>& plane,
+    std::vector<double>& inlier_probabilities,
+    int sampler_id,
+    bool use_magsac_plus_plus,
+    double sigma_max,
+    double conf,
+    int min_iters,
+    int max_iters,
+    int partition_num)
+{
+    magsac::utils::Default3DPlaneEstimator estimator;
+    gcransac::Model model;
+
+    MAGSAC<cv::Mat, magsac::utils::Default3DPlaneEstimator>* magsac;
+    if (use_magsac_plus_plus)
+        magsac = new MAGSAC<cv::Mat, magsac::utils::Default3DPlaneEstimator>(
+            MAGSAC<cv::Mat, magsac::utils::Default3DPlaneEstimator>::MAGSAC_PLUS_PLUS);
+    else
+        magsac = new MAGSAC<cv::Mat, magsac::utils::Default3DPlaneEstimator>(
+            MAGSAC<cv::Mat, magsac::utils::Default3DPlaneEstimator>::MAGSAC_ORIGINAL);
+
+    magsac->setMaximumThreshold(sigma_max);
+    magsac->setCoreNumber(1);
+    magsac->setPartitionNumber(partition_num);
+    magsac->setIterationLimit(max_iters);
+    magsac->setMinimumIterationNumber(min_iters);
+
+    ModelScore score;
+
+    int num_tents = pointsArr.size() / 3;
+    cv::Mat points(num_tents, 3, CV_64F, &pointsArr[0]);
+
+    typedef gcransac::sampler::Sampler<cv::Mat, size_t> AbstractSampler;
+    std::unique_ptr<AbstractSampler> main_sampler;
+    if (sampler_id == 0)
+        main_sampler = std::unique_ptr<AbstractSampler>(new gcransac::sampler::UniformSampler(&points));
+    else if (sampler_id == 1)
+        main_sampler = std::unique_ptr<AbstractSampler>(new gcransac::sampler::ProsacSampler(&points, estimator.sampleSize()));
+    else if (sampler_id == 3)
+        main_sampler = std::unique_ptr<AbstractSampler>(new gcransac::sampler::ImportanceSampler(&points,
+            inlier_probabilities,
+            estimator.sampleSize()));
+    else if (sampler_id == 4)
+    {
+        double variance = 0.1;
+        double max_prob = 0;
+        for (const auto &prob : inlier_probabilities)
+            max_prob = MAX(max_prob, prob);
+        for (auto &prob : inlier_probabilities)
+            prob /= max_prob;
+        main_sampler = std::unique_ptr<AbstractSampler>(new gcransac::sampler::AdaptiveReorderingSampler(&points,
+            inlier_probabilities,
+            estimator.sampleSize(),
+            variance));
+    }
+    else
+    {
+        fprintf(stderr, "Unknown sampler identifier: %d. The accepted samplers are 0 (uniform), 1 (PROSAC), 3 (NG-RANSAC), 4 (AR-Sampler)\n",
+            sampler_id);
+        return 0;
+    }
+
+    bool success = magsac->run(points,
+        conf,
+        estimator,
+        *main_sampler.get(),
+        model,
+        max_iters,
+        score);
+
+    inliers.resize(num_tents);
+    if (!success)
+    {
+        for (auto pt_idx = 0; pt_idx < points.rows; ++pt_idx)
+            inliers[pt_idx] = false;
+        plane.resize(4, 0);
+        return 0;
+    }
+
+    int num_inliers = 0;
+    for (auto pt_idx = 0; pt_idx < points.rows; ++pt_idx)
+    {
+        const int is_inlier = estimator.residual(points.row(pt_idx), model.descriptor) <= sigma_max;
+        inliers[pt_idx] = (bool)is_inlier;
+        num_inliers += is_inlier;
+    }
+
+    plane.resize(4);
+    for (int i = 0; i < 4; i++)
+        plane[i] = (double)model.descriptor(i);
+
+    AbstractSampler *sampler_ptr = main_sampler.release();
+    delete sampler_ptr;
+
+    return num_inliers;
+}
+
 int findHomography_(std::vector<double>& correspondences,
                     std::vector<bool>& inliers,
                     std::vector<double>& H,

--- a/tests/test_plane3d.py
+++ b/tests/test_plane3d.py
@@ -1,0 +1,149 @@
+"""Test ``pymagsac.findPlane3D``."""
+import pymagsac
+import numpy as np
+import pytest
+
+
+def generate_plane_data(
+    normal, offset, n_inliers=200, n_outliers=50, noise_std=0.01, seed=42
+):
+    """Generate 3D points on a plane with noise and outliers.
+
+    The plane is defined as normal . x + offset = 0.
+    """
+    rng = np.random.default_rng(seed)
+
+    # Generate random points in a tangent basis
+    # Find two vectors orthogonal to the normal
+    normal = np.array(normal, dtype=np.float64)
+    normal = normal / np.linalg.norm(normal)
+
+    # Pick an arbitrary vector not parallel to normal
+    if abs(normal[0]) < 0.9:
+        v = np.array([1.0, 0.0, 0.0])
+    else:
+        v = np.array([0.0, 1.0, 0.0])
+
+    t1 = np.cross(normal, v)
+    t1 /= np.linalg.norm(t1)
+    t2 = np.cross(normal, t1)
+
+    # Generate inlier points on the plane
+    coords = rng.uniform(-10, 10, (n_inliers, 2))
+    # Point on the plane closest to origin
+    base_point = -offset * normal
+    inliers = base_point + coords[:, 0:1] * t1 + coords[:, 1:2] * t2
+    # Add Gaussian noise
+    inliers += rng.normal(0, noise_std, inliers.shape)
+
+    # Generate outlier points randomly in a cube
+    outliers = rng.uniform(-15, 15, (n_outliers, 3))
+
+    points = np.vstack([inliers, outliers])
+    gt_inlier_mask = np.zeros(len(points), dtype=bool)
+    gt_inlier_mask[:n_inliers] = True
+
+    return points, gt_inlier_mask
+
+
+def verify_plane(
+    points,
+    sigma_th=0.1,
+    sampler_id=0,
+    use_magsac_plus_plus=True,
+    min_iters=500,
+    max_iters=5000,
+):
+    plane, mask = pymagsac.findPlane3D(
+        np.ascontiguousarray(points),
+        probabilities=[],
+        min_iters=min_iters,
+        max_iters=max_iters,
+        sampler=sampler_id,
+        use_magsac_plus_plus=use_magsac_plus_plus,
+        sigma_th=sigma_th,
+    )
+    return plane, mask
+
+
+def angle_between_normals(n1, n2):
+    """Angle in degrees between two plane normals (handles sign ambiguity)."""
+    n1 = n1 / np.linalg.norm(n1)
+    n2 = n2 / np.linalg.norm(n2)
+    cos_angle = np.clip(abs(np.dot(n1, n2)), -1.0, 1.0)
+    return np.degrees(np.arccos(cos_angle))
+
+
+@pytest.mark.parametrize("use_magsac_plus_plus", [True, False])
+def test_plane_fitting_basic(use_magsac_plus_plus):
+    """Test plane fitting with a simple horizontal plane z=5."""
+    gt_normal = np.array([0.0, 0.0, 1.0])
+    gt_offset = -5.0  # plane: 0*x + 0*y + 1*z - 5 = 0
+
+    points, gt_mask = generate_plane_data(
+        gt_normal, gt_offset, n_inliers=200, n_outliers=50, noise_std=0.01
+    )
+
+    plane, mask = verify_plane(
+        points,
+        sigma_th=0.1,
+        use_magsac_plus_plus=use_magsac_plus_plus,
+    )
+
+    assert plane is not None, "Plane fitting failed"
+
+    # Check normal direction (up to sign)
+    est_normal = plane[:3]
+    angle_err = angle_between_normals(gt_normal, est_normal)
+    assert angle_err < 2.0, f"Normal angle error {angle_err:.2f} degrees"
+
+    # Check that most inliers are found
+    n_inliers_found = np.sum(mask)
+    assert n_inliers_found > 150, f"Only {n_inliers_found} inliers found"
+
+
+@pytest.mark.parametrize(
+    "normal",
+    [
+        [1.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [1.0, 1.0, 1.0],
+        [0.3, -0.7, 0.5],
+    ],
+)
+def test_plane_fitting_orientations(normal):
+    """Test plane fitting with various orientations."""
+    points, gt_mask = generate_plane_data(
+        normal, offset=3.0, n_inliers=300, n_outliers=100, noise_std=0.005
+    )
+
+    plane, mask = verify_plane(points, sigma_th=0.05)
+
+    assert plane is not None, "Plane fitting failed"
+
+    est_normal = plane[:3]
+    angle_err = angle_between_normals(normal, est_normal)
+    assert angle_err < 2.0, f"Normal angle error {angle_err:.2f} degrees"
+
+
+def test_plane_fitting_high_outlier_ratio():
+    """Test plane fitting with 50% outliers."""
+    gt_normal = np.array([0.0, 0.0, 1.0])
+    points, gt_mask = generate_plane_data(
+        gt_normal, offset=0.0, n_inliers=200, n_outliers=200, noise_std=0.01
+    )
+
+    plane, mask = verify_plane(points, sigma_th=0.1, max_iters=10000)
+
+    assert plane is not None, "Plane fitting failed with 50% outliers"
+
+    est_normal = plane[:3]
+    angle_err = angle_between_normals(gt_normal, est_normal)
+    assert angle_err < 3.0, f"Normal angle error {angle_err:.2f} degrees"
+
+
+def test_plane_fitting_insufficient_points():
+    """Test that plane fitting raises with fewer than 3 points."""
+    points = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
+    with pytest.raises(Exception):
+        verify_plane(points)


### PR DESCRIPTION
# PR 2: feat: add 3D plane fitting support

**Branch:** `feature/plane-fitting-pr`
**Base:** `master`
**From:** `f-dy/magsac` → `danini/magsac`

## Description

Add `findPlane3D` function for robust 3D plane estimation from point clouds using MAGSAC/MAGSAC++.

A plane is fitted from a minimum sample of 3 points using cross-product normal estimation. The model is represented as `[a, b, c, d]` where `ax + by + cz + d = 0` and `[a, b, c]` is the unit normal.

### API

```python
plane, inliers = pymagsac.findPlane3D(
    points,            # (N, 3) array of 3D points
    probabilities=[],  # optional inlier probabilities
    sampler=0,         # 0=uniform, 1=PROSAC, 3=NG-RANSAC, 4=AR-Sampler
    use_magsac_plus_plus=True,
    sigma_th=1.0,      # maximum threshold
    conf=0.99,         # confidence
    min_iters=50,
    max_iters=1000,
    partition_num=5,
)
# plane: (4,) array [a, b, c, d] or None if fitting fails
# inliers: (N,) boolean mask
```

### Changes

- `src/pymagsac/include/estimators.h` — Add `Plane3DEstimator` class using `LinearModelEstimator<3>`
- `src/pymagsac/include/magsac_python.hpp` — Declare `findPlane3D_`
- `src/pymagsac/src/magsac_python.cpp` — Implement `findPlane3D_`
- `src/pymagsac/src/bindings.cpp` — Add Python binding
- `tests/test_plane3d.py` — Unit tests (8 tests)

### Implementation notes

The 3D plane solver (`LinearModelSolver<3>::estimate3DPlane`) already existed in graph-cut-ransac. This PR adds the MAGSAC estimator wrapper and Python binding, following the same pattern as the existing `findLine2D` function.

## Testing

- 8 unit tests pass covering: basic fitting, multiple orientations, high outlier ratio (50%), and input validation
- Tested with both MAGSAC and MAGSAC++ modes

## Command to create PR

```bash
gh pr create --repo danini/magsac --base master --head f-dy:feature/plane-fitting-pr \
  --title "feat: add 3D plane fitting support" \
  --body-file /Users/deverf/Documents/third_party/magsac-fixes/PR2-draft.md
```
