### PR TITLE
fix: make OpenMP optional and add macOS wheel builds

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -19,12 +19,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
+
+      - name: Install OpenMP on macOS
+        if: matrix.os == 'macos-latest'
+        run: brew install libomp
 
       - name: Setup MSVC Developer Command Prompt
         if: matrix.os == 'windows-latest'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,13 +57,29 @@ set(EIGEN_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR})
 # ==============================================================================
 # Find OpenMP
 # ==============================================================================
+if(APPLE AND USE_OPENMP)
+	# Help CMake find Homebrew's libomp on macOS
+	execute_process(COMMAND brew --prefix libomp
+		OUTPUT_VARIABLE LIBOMP_PREFIX
+		OUTPUT_STRIP_TRAILING_WHITESPACE
+		ERROR_QUIET)
+	if(LIBOMP_PREFIX)
+		set(OpenMP_CXX_FLAGS "-Xclang -fopenmp" CACHE STRING "" FORCE)
+		set(OpenMP_CXX_LIB_NAMES "omp" CACHE STRING "" FORCE)
+		set(OpenMP_omp_LIBRARY "${LIBOMP_PREFIX}/lib/libomp.dylib" CACHE STRING "" FORCE)
+		include_directories("${LIBOMP_PREFIX}/include")
+	endif()
+endif()
+
 find_package(OpenMP)
 if (USE_OPENMP)
 	if(NOT OPENMP_FOUND)
-		message(FATAL_ERROR "OPENMP not found.")
+		message(WARNING "OpenMP not found. Building without OpenMP support.")
+		set(USE_OPENMP OFF)
+	else()
+		add_definitions(-DUSE_OPENMP)
+		set(TRGT_LNK_LBS_ADDITIONAL OpenMP::OpenMP_CXX)
 	endif()
-	add_definitions(-DUSE_OPENMP)
-	set(TRGT_LNK_LBS_ADDITIONAL OpenMP::OpenMP_CXX)
 endif (USE_OPENMP)
 
 # ==============================================================================


### PR DESCRIPTION
## Description

Make OpenMP optional so the package can be pip-installed on macOS (where Apple clang does not bundle OpenMP).

### Changes

- **CMakeLists.txt:** Auto-detect Homebrew's `libomp` on macOS via `brew --prefix libomp`. If OpenMP is still not found, warn and continue without it (graceful degradation, matching scikit-learn's approach).
- **CI (.github/workflows/build-and-deploy.yml):** Add `macos-latest` to the wheel build matrix with `brew install libomp`, so published macOS wheels include OpenMP support.

### For users building from source on macOS

```bash
brew install libomp
pip install .
```

OpenMP will be auto-detected. Without `libomp`, the build succeeds but runs single-threaded.

### Testing

- `pip install .` succeeds on macOS with and without `libomp` installed
- With `libomp`: OpenMP is detected and enabled
- Without `libomp`: warning printed, build continues without OpenMP