### PR TITLE
fix: derive MAGSAC reference threshold from sigma_max (existing estimators)

### DIFF
--- a/src/pymagsac/src/magsac_python.cpp
+++ b/src/pymagsac/src/magsac_python.cpp
@@ -45,6 +45,10 @@ int findRigidTransformation_(
         magsac = new MAGSAC<cv::Mat, magsac::utils::DefaultRigidTransformationEstimator>(
             MAGSAC<cv::Mat, magsac::utils::DefaultRigidTransformationEstimator>::MAGSAC_ORIGINAL);
     magsac->setMaximumThreshold(sigma_max); // The maximum noise scale sigma allowed
+    // Reference threshold for the adaptive iteration count, derived from the noise
+    // scale (k*sigma_max = the statistical inlier threshold) instead of the
+    // pixel-unit default of 1.0, so the iteration budget is unit-independent.
+    magsac->setReferenceThreshold(magsac::utils::DefaultRigidTransformationEstimator::getSigmaQuantile() * sigma_max);
     magsac->setCoreNumber(1); // The number of cores used to speed up sigma-consensus
     magsac->setPartitionNumber(partition_num); // The number partitions used for speeding up sigma consensus. As the value grows, the algorithm become slower and, usually, more accurate.
     magsac->setIterationLimit(max_iters);
@@ -180,6 +184,10 @@ int findFundamentalMatrix_(
         magsac = new MAGSAC<cv::Mat, magsac::utils::DefaultFundamentalMatrixEstimator>(
             MAGSAC<cv::Mat, magsac::utils::DefaultFundamentalMatrixEstimator>::MAGSAC_ORIGINAL);
     magsac->setMaximumThreshold(sigma_max); // The maximum noise scale sigma allowed
+    // Reference threshold for the adaptive iteration count, derived from the noise
+    // scale (k*sigma_max = the statistical inlier threshold) instead of the
+    // pixel-unit default of 1.0, so the iteration budget is unit-independent.
+    magsac->setReferenceThreshold(magsac::utils::DefaultFundamentalMatrixEstimator::getSigmaQuantile() * sigma_max);
     magsac->setCoreNumber(1); // The number of cores used to speed up sigma-consensus
     magsac->setPartitionNumber(partition_num); // The number partitions used for speeding up sigma consensus. As the value grows, the algorithm become slower and, usually, more accurate.
     magsac->setIterationLimit(max_iters);
@@ -354,7 +362,11 @@ int findEssentialMatrix_(std::vector<double>& correspondences,
     magsac.setPartitionNumber(partition_num); // The number partitions used for speeding up sigma consensus. As the value grows, the algorithm become slower and, usually, more accurate.
     magsac.setIterationLimit(max_iters);
 	magsac.setMinimumIterationNumber(min_iters);
-    magsac.setReferenceThreshold(magsac.getReferenceThreshold() / threshold_normalizer); // The reference threshold inside MAGSAC++ should also be normalized.
+    // Reference threshold for the adaptive iteration count, derived from the
+    // (normalized) noise scale rather than rescaling the arbitrary 1.0 default:
+    // k*sigma_max = the statistical inlier threshold, so the iteration budget is
+    // unit-independent.
+    magsac.setReferenceThreshold(magsac::utils::DefaultEssentialMatrixEstimator::getSigmaQuantile() * normalized_sigma_max);
 	
 	// Initialize the samplers
 	// The main sampler is used for sampling in the main RANSAC loop
@@ -499,6 +511,10 @@ int findLine2D_(std::vector<double>& pointsArr,
             MAGSAC<cv::Mat, magsac::utils::Default2DLineEstimator>::MAGSAC_ORIGINAL);
 
     magsac->setMaximumThreshold(sigma_max); // The maximum noise scale sigma allowed
+    // Reference threshold for the adaptive iteration count, derived from the noise
+    // scale (k*sigma_max = the statistical inlier threshold) instead of the
+    // pixel-unit default of 1.0, so the iteration budget is unit-independent.
+    magsac->setReferenceThreshold(magsac::utils::Default2DLineEstimator::getSigmaQuantile() * sigma_max);
     magsac->setCoreNumber(1); // The number of cores used to speed up sigma-consensus
     magsac->setPartitionNumber(partition_num); // The number partitions used for speeding up sigma consensus. As the value grows, the algorithm become slower and, usually, more accurate.
     magsac->setIterationLimit(max_iters);
@@ -619,6 +635,10 @@ int findHomography_(std::vector<double>& correspondences,
             MAGSAC<cv::Mat, magsac::utils::DefaultHomographyEstimator>::MAGSAC_ORIGINAL);
 
     magsac->setMaximumThreshold(sigma_max); // The maximum noise scale sigma allowed
+    // Reference threshold for the adaptive iteration count, derived from the noise
+    // scale (k*sigma_max = the statistical inlier threshold) instead of the
+    // pixel-unit default of 1.0, so the iteration budget is unit-independent.
+    magsac->setReferenceThreshold(magsac::utils::DefaultHomographyEstimator::getSigmaQuantile() * sigma_max);
     magsac->setCoreNumber(1); // The number of cores used to speed up sigma-consensus
     magsac->setPartitionNumber(partition_num); // The number partitions used for speeding up sigma consensus. As the value grows, the algorithm become slower and, usually, more accurate.
     magsac->setIterationLimit(max_iters);


### PR DESCRIPTION
# fix: derive the MAGSAC reference threshold from sigma_max (existing estimators)

## Problem

The pybind `find*_` functions in `src/pymagsac/src/magsac_python.cpp` leave the MAGSAC
reference threshold (`interrupting_threshold`, `magsac.h`) at its constructor default
of **1.0**. It counts "confident" inliers (`residual < interrupting_threshold`), which
drives the adaptive iteration count:

```cpp
last_iteration_number = log(1−conf) / log(1 − (inlier_number / N)^sample_size);
```

`1.0` is not a principled value:

- **Pixel estimators** (homography, fundamental, essential): SIFT at coarse scales (and
  ASIFT, dense matches) has inlier localization error of several pixels; inlier
  thresholds are commonly 3–5 px. A `1.0`-px reference under-counts genuine inliers.
- **Metric estimators** (rigid transformation, line): `1.0` is in data units, so
  identical geometry in mm vs m vs inches yields different iteration budgets.

This affects the **RANSAC search budget** — the number of samples drawn — and therefore,
on hard problems, *which model is found*. It does not change the per-hypothesis
weight/loss math. Previously only `findEssentialMatrix_` touched it, merely rescaling
the arbitrary `1.0` by the coordinate normalizer (still rooted in `1.0`).

## Fix

Derive the reference threshold from the noise scale, uniformly:

```cpp
magsac->setReferenceThreshold(EstimatorType::getSigmaQuantile() * sigma_max);
```

`k = getSigmaQuantile() = sqrt(chi2_0.99(DoF))` makes this the statistical inlier
threshold `τ = k·σ_max` — scale-invariant and consistent with the MAGSAC++ weight/loss
cutoff. Using `getSigmaQuantile()` (rather than a hardcoded `k`) keeps it correct before
and after any per-estimator DoF change. The normalized essential estimator uses
`k · normalized_sigma_max`.

## Scope

Covers the **pre-existing** estimators on `master`: rigid transformation, fundamental,
essential, line, homography. **Independent of other PRs** — branched from and mergeable
into `master` on its own (22-line diff, one file).

The estimators added in danini/magsac#45 (plane, PnP, radial homography, affine,
planar/gravity essential) set this from the start in that PR, so they are not touched
here.

## Note on validation

This changes the iteration budget of estimators that existing users rely on. It is
low-severity (search budget / runtime, not the per-hypothesis scoring), but should be
validated on the paper's datasets (Adelaide / EVD / homogr) for failure-rate / accuracy
regressions before merging.
