### PR TITLE
feat: add optional random seed to the Python estimators

### DIFF
--- a/src/pymagsac/include/magsac_python.hpp
+++ b/src/pymagsac/include/magsac_python.hpp
@@ -2,6 +2,10 @@
 #include <vector>
 #include <opencv2/core/core.hpp>
 
+// Make RANSAC sampling reproducible when seed >= 0, else restore the default
+// nondeterministic behavior. Implemented in magsac_python.cpp.
+void applyMagsacSeed(int seed);
+
 int adaptiveInlierSelection_(
     const std::vector<double>& srcPts_,
     const std::vector<double>& dstPts_,

--- a/src/pymagsac/src/bindings.cpp
+++ b/src/pymagsac/src/bindings.cpp
@@ -7,6 +7,7 @@
 
 namespace py = pybind11;
 
+
 py::tuple adaptiveInlierSelection(
     py::array_t<double>  x1y1_,
     py::array_t<double>  x2y2_,
@@ -89,7 +90,8 @@ py::tuple findRigidTransformation(
     double conf,
     int min_iters,
     int max_iters,
-    int partition_num)
+    int partition_num,
+    int seed)
 {
 	py::buffer_info buf1 = correspondences_.request();
 	size_t NUM_TENTS = buf1.shape[0];
@@ -117,6 +119,7 @@ py::tuple findRigidTransformation(
         probabilities.assign(ptr_prob, ptr_prob + buf_prob.size);        
     }
 
+    applyMagsacSeed(seed);
     int num_inl = findRigidTransformation_(
         correspondences,
         inliers,
@@ -159,7 +162,8 @@ py::tuple findFundamentalMatrix(
     double conf,
     int min_iters,
     int max_iters,
-    int partition_num)
+    int partition_num,
+    int seed)
 {
 	py::buffer_info buf1 = correspondences_.request();
 	size_t NUM_TENTS = buf1.shape[0];
@@ -187,6 +191,7 @@ py::tuple findFundamentalMatrix(
         probabilities.assign(ptr_prob, ptr_prob + buf_prob.size);        
     }
 
+    applyMagsacSeed(seed);
     int num_inl = findFundamentalMatrix_(
         correspondences,
         inliers,
@@ -235,7 +240,8 @@ py::tuple findEssentialMatrix(
     double conf,
     int min_iters,
     int max_iters,
-    int partition_num) 
+    int partition_num,
+    int seed) 
 {
 	py::buffer_info buf1 = correspondences_.request();
 	size_t NUM_TENTS = buf1.shape[0];
@@ -285,6 +291,7 @@ py::tuple findEssentialMatrix(
         probabilities.assign(ptr_prob, ptr_prob + buf_prob.size);        
     }
 
+    applyMagsacSeed(seed);
     int num_inl = findEssentialMatrix_(
         correspondences,
         inliers,
@@ -333,7 +340,8 @@ py::tuple findLine2D(
     double conf,
     int min_iters,
     int max_iters,
-    int partition_num) 
+    int partition_num,
+    int seed) 
 {
     py::buffer_info buf1 = points_.request();
 	size_t NUM_TENTS = buf1.shape[0];
@@ -359,6 +367,7 @@ py::tuple findLine2D(
         probabilities.assign(ptr_prob, ptr_prob + buf_prob.size);        
     }
     
+    applyMagsacSeed(seed);
     int num_inl = findLine2D_(
         points,
         inliers,
@@ -405,7 +414,8 @@ py::tuple findHomography(
     double conf,
     int min_iters,
     int max_iters,
-    int partition_num) 
+    int partition_num,
+    int seed) 
 {
 	py::buffer_info buf1 = correspondences_.request();
 	size_t NUM_TENTS = buf1.shape[0];
@@ -433,6 +443,7 @@ py::tuple findHomography(
         probabilities.assign(ptr_prob, ptr_prob + buf_prob.size);        
     }
     
+    applyMagsacSeed(seed);
     int num_inl = findHomography_(
                     correspondences,
                     inliers,
@@ -506,7 +517,8 @@ PYBIND11_PLUGIN(pymagsac) {
         py::arg("conf") = 0.99,
         py::arg("min_iters") = 50,
         py::arg("max_iters") = 1000,
-        py::arg("partition_num") = 5);
+        py::arg("partition_num") = 5,
+        py::arg("seed") = -1);
 
     m.def("findFundamentalMatrix", &findFundamentalMatrix, R"doc(some doc)doc",
         py::arg("correspondences"),
@@ -521,7 +533,8 @@ PYBIND11_PLUGIN(pymagsac) {
         py::arg("conf") = 0.99,
         py::arg("min_iters") = 50,
         py::arg("max_iters") = 1000,
-        py::arg("partition_num") = 5);
+        py::arg("partition_num") = 5,
+        py::arg("seed") = -1);
 
     m.def("findRigidTransformation", &findRigidTransformation, R"doc(some doc)doc",
         py::arg("correspondences"),
@@ -532,7 +545,8 @@ PYBIND11_PLUGIN(pymagsac) {
         py::arg("conf") = 0.99,
         py::arg("min_iters") = 50,
         py::arg("max_iters") = 1000,
-        py::arg("partition_num") = 5);
+        py::arg("partition_num") = 5,
+        py::arg("seed") = -1);
 
   m.def("findHomography", &findHomography, R"doc(some doc)doc",
         py::arg("correspondences"),
@@ -547,7 +561,8 @@ PYBIND11_PLUGIN(pymagsac) {
         py::arg("conf") = 0.99,
         py::arg("min_iters") = 50,
         py::arg("max_iters") = 1000,
-        py::arg("partition_num") = 5); 
+        py::arg("partition_num") = 5,
+        py::arg("seed") = -1); 
 
   m.def("findLine2D", &findLine2D, R"doc(some doc)doc",
         py::arg("points"),
@@ -560,7 +575,8 @@ PYBIND11_PLUGIN(pymagsac) {
         py::arg("conf") = 0.99,
         py::arg("min_iters") = 50,
         py::arg("max_iters") = 1000,
-        py::arg("partition_num") = 5); 
+        py::arg("partition_num") = 5,
+        py::arg("seed") = -1); 
 
 
   return m.ptr();

--- a/src/pymagsac/src/magsac_python.cpp
+++ b/src/pymagsac/src/magsac_python.cpp
@@ -20,6 +20,23 @@
 
 #include <gflags/gflags.h>
 
+#include <cstdlib>
+#include <cstdint>
+
+// Make RANSAC sampling reproducible when seed >= 0, else restore nondeterministic
+// behavior. setGlobalSeed covers all UniformRandomGenerator-based samplers;
+// std::srand covers samplers/solvers that use std::rand()/Eigen::Random.
+void applyMagsacSeed(int seed)
+{
+    if (seed >= 0)
+    {
+        gcransac::utils::UniformRandomGenerator<size_t>::setGlobalSeed(static_cast<std::uint64_t>(seed));
+        std::srand(static_cast<unsigned>(seed));
+    }
+    else
+        gcransac::utils::UniformRandomGenerator<size_t>::clearGlobalSeed();
+}
+
 int findRigidTransformation_(
     std::vector<double>& correspondences,
     std::vector<bool>& inliers,


### PR DESCRIPTION
# feat: add optional random seed to the Python estimators

## What

Adds a `seed` argument (default `-1` = nondeterministic, unchanged behavior) to
the five Python estimators in `bindings.cpp`:

- `findHomography`, `findFundamentalMatrix`, `findEssentialMatrix`,
  `findRigidTransformation`, `findLine2D`

```python
H, mask = pymagsac.findHomography(corrs, w1, h1, w2, h2, seed=42)  # reproducible
```

## Why

There is currently no way to make MAGSAC/MAGSAC++ runs reproducible, which makes
debugging non-deterministic results difficult. A fixed seed gives repeatable
sampling.

## How

A small helper sets the seed before the estimator builds its sampler:

```cpp
if (seed >= 0) {
    gcransac::utils::UniformRandomGenerator<size_t>::setGlobalSeed(seed); // all URG samplers
    std::srand(seed);                                                     // rand()/Eigen::Random
} else
    gcransac::utils::UniformRandomGenerator<size_t>::clearGlobalSeed();
```

- `setGlobalSeed` makes all `UniformRandomGenerator`-based samplers
  (Uniform / PROSAC / Progressive-NAPSAC / Importance) deterministic.
- `std::srand(seed)` covers the samplers/solvers that use `std::rand()` /
  `Eigen::…::Random()` (`AdaptiveReorderingSampler`, PnP bundle-adjustment,
  DLS/SIFT solvers).
- `seed < 0` restores the previous `std::random_device` behavior.

## ⚠️ Dependency

**This PR depends on https://github.com/danini/graph-cut-ransac/pull/51**
("add a process-wide random seed to `UniformRandomGenerator`"), which introduces
`UniformRandomGenerator::setGlobalSeed`/`clearGlobalSeed`.

The submodule bump to the gcransac commit carrying #51 is **intentionally not
included** in this PR (to keep the diff minimal and avoid pinning a fork commit).
It should be applied once #51 is merged into `graph-cut-ransac` master. Until
then this branch will not compile against the currently-pinned submodule.

## Scope / follow-up

Covers the five estimators present on `master`. The additional estimators added
in #45 (plane, PnP, radial homography, affine/essential variants) get the same
`seed` parameter in a follow-up once #45 lands.
